### PR TITLE
[Chore]: CI 스킵 로직 최적화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
   lint:
     name: Lint (SwiftFormat & SwiftLint)
     needs: changes
+    if: ${{ needs.changes.outputs.lint == 'true' }}
     runs-on: macos-14
     timeout-minutes: 15
     steps:
@@ -72,7 +73,6 @@ jobs:
 
       - name: Detect Swift files
         id: has_swift
-        if: ${{ needs.changes.outputs.lint == 'true' }}
         run: |
           if git ls-files '*.swift' | grep -q .; then
             echo "present=true" >> $GITHUB_OUTPUT
@@ -81,59 +81,43 @@ jobs:
           fi
 
       - name: Install tools
-        if: ${{ needs.changes.outputs.lint == 'true' && steps.has_swift.outputs.present == 'true' }}
+        if: ${{ steps.has_swift.outputs.present == 'true' }}
         run: |
           brew update
           brew install swiftformat swiftlint
 
       - name: SwiftFormat (lint mode)
-        if: ${{ needs.changes.outputs.lint == 'true' && steps.has_swift.outputs.present == 'true' }}
+        if: ${{ steps.has_swift.outputs.present == 'true' }}
         run: |
           echo "Running SwiftFormat in lint mode…"
           swiftformat --lint . --config .swiftformat
 
       - name: SwiftLint (strict, no cache)
-        if: ${{ needs.changes.outputs.lint == 'true' && steps.has_swift.outputs.present == 'true' }}
+        if: ${{ steps.has_swift.outputs.present == 'true' }}
         run: |
           echo "Running SwiftLint…"
           swiftlint --strict --quiet --no-cache --reporter github-actions-logging
 
       - name: Skip Lint (no Swift files)
-        if: ${{ needs.changes.outputs.lint == 'true' && steps.has_swift.outputs.present != 'true' }}
+        if: ${{ steps.has_swift.outputs.present != 'true' }}
         run: echo "No Swift files in repo yet. Skipping lint."
-
-      - name: No lint changes
-        if: ${{ needs.changes.outputs.lint != 'true' }}
-        run: echo "No files requiring a lint check were changed. Skipping."
 
   build-test:
     name: Build & Unit Test
     needs: [changes, lint]
-    if: ${{ always() }}
+    if: ${{ needs.changes.outputs.code == 'true' && (needs.lint.result == 'success' || needs.lint.result == 'skipped') }}
     runs-on: macos-14
     timeout-minutes: 60
     steps:
-      - name: Enforce Lint Success
-        if: ${{ needs.changes.outputs.lint == 'true' && needs.lint.result == 'failure' }}
-        run: |
-          echo "Lint job failed. Aborting build and test."
-          exit 1
-
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: No code changes
-        if: ${{ needs.changes.outputs.code != 'true' }}
-        run: echo "No code files were changed. Skipping build and test."
-
       - name: Select Xcode
-        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '16.2'
 
       - name: Cache SPM
-        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: actions/cache@v4
         with:
           path: |
@@ -144,7 +128,6 @@ jobs:
             ${{ runner.os }}-spm-
 
       - name: Cache Tuist Dependencies
-        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: actions/cache@v4
         with:
           path: Tuist/Dependencies
@@ -153,17 +136,14 @@ jobs:
             ${{ runner.os }}-tuist-
 
       - name: Setup mise (Tuist via mise)
-        if: ${{ needs.changes.outputs.code == 'true' }}
         uses: jdx/mise-action@v2
 
       - name: Install tools via mise
-        if: ${{ needs.changes.outputs.code == 'true' }}
         run: |
           mise install
           tuist version
 
       - name: Setup utilities
-        if: ${{ needs.changes.outputs.code == 'true' }}
         run: |
           brew update
           brew install swiftgen xcbeautify
@@ -171,15 +151,12 @@ jobs:
           swiftgen --version
 
       - name: Tuist Install (resolve deps)
-        if: ${{ needs.changes.outputs.code == 'true' }}
         run: tuist install
 
       - name: Tuist Generate
-        if: ${{ needs.changes.outputs.code == 'true' }}
         run: tuist generate --no-open
 
       - name: Pick & Boot Simulator
-        if: ${{ needs.changes.outputs.code == 'true' }}
         id: sim
         run: |
           SIM_ID=$(xcrun simctl list devices available | awk -F '[()]' '/iPhone/{print $2; exit}')
@@ -190,7 +167,6 @@ jobs:
           xcrun simctl boot "$SIM_ID" || true
 
       - name: Build & Test
-        if: ${{ needs.changes.outputs.code == 'true' }}
         env:
           SIM_ID: ${{ steps.sim.outputs.SIM_ID }}
         run: |
@@ -203,7 +179,7 @@ jobs:
             clean test | tee xcodebuild.log | xcbeautify
 
       - name: Upload Xcode Build Log on Failure
-        if: ${{ failure() && needs.changes.outputs.code == 'true' }}
+        if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
           name: xcodebuild-log


### PR DESCRIPTION
## 🔮 작업 요약

빌드/린트 관련 코드 변경이 없을 때 CI job을 스킵하여 불필요한 runner 실행을 방지합니다.

## 🖥️ 상세 작업 내용

### 변경 전
- `lint` job: 항상 macos-14 runner에서 실행 (내부에서 조건 체크)
- `build-test` job: `always()` 조건으로 항상 실행

### 변경 후
- `lint` job: Swift 파일 변경 시에만 job 실행
- `build-test` job: 코드 변경 시에만 job 실행

## 📊 기대 효과

| 변경 유형 | Lint | Build & Test |
| :-------: | :--: | :----------: |
| Swift 파일 변경 | ✅ 실행 | ✅ 실행 |
| 문서만 변경 | ⏭️ 스킵 | ⏭️ 스킵 |
| CI 설정만 변경 | ⏭️ 스킵 | ⏭️ 스킵 |
| 라벨 설정만 변경 | ⏭️ 스킵 | ⏭️ 스킵 |

- macos-14 runner 비용 절감
- PR 피드백 속도 향상